### PR TITLE
Fix consolidate tests.

### DIFF
--- a/.github/workflows/consolidate-tests.yml
+++ b/.github/workflows/consolidate-tests.yml
@@ -1,0 +1,22 @@
+name: Consolidate Tests
+
+on:
+  pull_request:
+    paths:
+      - 'consolidate/**'
+      - '.github/workflows/consolidate-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+      
+      - name: Run tests
+        working-directory: ./consolidate
+        run: go test -v ./...


### PR DESCRIPTION
When implementing consolidation of atone addresses, I started to get different values for the distribution. After some time, I realized that tests were not passing before my changes.

Added a CI job to execute tests on all PRs changing the consolidate folder.