### PR TITLE
fix: reconcile finalized GNOT allocations

### DIFF
--- a/consolidate/process_consolidated.go
+++ b/consolidate/process_consolidated.go
@@ -37,8 +37,9 @@ type Distribution struct {
 const (
 	TOTAL_AIRDROP_ATOM            = 350000000
 	TOTAL_AIRDROP_ATONE           = 231000000
-	TOTAL_AIRDROP_CONTRIBS        = 119000000
+	TOTAL_AIRDROP_CONTRIBS        = 119993000
 	TOTAL_AIRDROP_NT              = 300000000
+	TOTAL_AIRDROP_NT_LLC          = 332000000
 	TOTAL_AIRDROP_GOVDAO_FOUNDERS = 7000
 
 	MULTISIG_NT1_ADDRESS    = "g1pxj9x5jkklzam9v76q7sn7grm0xnuj69qu7lmf" //nt1: nt llc + investors
@@ -115,7 +116,7 @@ func main() {
 			Address: MULTISIG_NT1_ADDRESS,
 		},
 		GnoAddress: MULTISIG_NT1_ADDRESS,
-		Ugnot:      types.NewDec(int64(TOTAL_AIRDROP_NT) * 1000000),
+		Ugnot:      types.NewDec(int64(TOTAL_AIRDROP_NT+TOTAL_AIRDROP_NT_LLC) * 1000000),
 	}
 
 	// Allocate GovDAO founders budget (1000 GNOT each)

--- a/consolidate/process_test.go
+++ b/consolidate/process_test.go
@@ -34,6 +34,19 @@ var (
 
 const TOTAL_AIRDROP_TESTS = 700000000
 
+func TestFinalizedSupplyConstants(t *testing.T) {
+	assert.Equal(t, 632000000, TOTAL_AIRDROP_NT+TOTAL_AIRDROP_NT_LLC)
+	assert.Equal(t, 120000000, TOTAL_AIRDROP_CONTRIBS+TOTAL_AIRDROP_GOVDAO_FOUNDERS)
+	assert.Equal(t, 1333000000,
+		TOTAL_AIRDROP_ATOM+
+			TOTAL_AIRDROP_ATONE+
+			TOTAL_AIRDROP_NT+
+			TOTAL_AIRDROP_NT_LLC+
+			TOTAL_AIRDROP_CONTRIBS+
+			TOTAL_AIRDROP_GOVDAO_FOUNDERS,
+	)
+}
+
 func TestConvertAddress(t *testing.T) {
 	test2, err := convertAddress(test2_address_cosmos, "cosmos")
 	assert.NoError(t, err)
@@ -205,7 +218,7 @@ func TestTotal(t *testing.T) {
 		sum = sum.Add(amount_dec)
 	}
 
-	expected := types.MustNewDecFromStr("1000007000000000.000000000000000000")
+	expected := types.MustNewDecFromStr("1333000000000000.000000000000000000")
 	delta := expected.Mul(types.NewDecWithPrec(1, 4)) // 0.01%
 	diff := sum.Sub(expected).Abs()
 


### PR DESCRIPTION
## Summary

- add the 332M NT, LLC allocation to `MULTISIG_NT1_ADDRESS`, per the decision in #44
- make GovDAO T1 total exactly 120M by keeping the 7,000 founders allocation inside the bucket
- regenerate `consolidate/genbalance.txt.gz`
- add a constants-level test for the finalized 1.333B supply breakdown

## Allocation check

- Cosmos airdrop: 350M
- AtomOne airdrop: 231M
- Investors + NT, LLC to NT1: 300M + 332M = 632M
- GovDAO T1: 119.993M multisig + 0.007M founders = 120M
- Total constants: 1.333B GNOT

## Verification

```sh
go test ./consolidate
```

Also checked generated lines:

```text
MULTISIG_NT1_ADDRESS    = 632000000000000ugnot
MULTISIG_GOVDAO_ADDRESS = 119993000000000ugnot
one founder address     = 1000000000ugnot
```

Closes #44